### PR TITLE
Ruby doesnt respect ftp_proxy

### DIFF
--- a/config/software/libxslt.rb
+++ b/config/software/libxslt.rb
@@ -29,7 +29,7 @@ version "1.1.28" do
   source md5: "9667bf6f9310b957254fdcf6596600b7"
 end
 
-source url: "ftp://xmlsoft.org/libxml2/libxslt-#{version}.tar.gz"
+source url: "http://xmlsoft.org/sources/libxslt-#{version}.tar.gz"
 
 relative_path "libxslt-#{version}"
 


### PR DESCRIPTION
Ruby (or whatever packages omnibus is using behind the scenes) doesnt respect ftp_proxy settings. Switching the libxml to use http so omnibus builds will properly work behind corporate firewalls. We have encountered this problem at Bloomberg so please accept this pull request.
